### PR TITLE
Increase number of shown items to 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     getValue: "n",
 
     list: {
-
+      maxNumberOfElements: 10,
       onChooseEvent: function() {
         var id = $("#provider-remote").getSelectedItemData().i;
         var name = $("#provider-remote").getSelectedItemData().n;


### PR DESCRIPTION
I find that 4 items is too few to find certain stops if I only know one cross-street. For example, if I want to search for Randolph and Stanage, I have to search for "Stanage" because "Randolph" has too many other stops.